### PR TITLE
Add installer for ZIP-based distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 __pycache__/
 *.pyc
 output.xlsx
+# Distribution artifacts
+Lernkarten.zip
+start.sh
+start.bat
+start.py

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ und CSV (z. B. für Anki).
    - macOS/Linux: `bash run.sh`
 4. In der GUI: **Skript wählen**, **API‑Key eingeben**, **Gründlichkeit** & **Budget** setzen, **Schätzen** → **Start**.
 
+## Installation aus ZIP
+1. `Lernkarten.zip` und `installer.py` in denselben Ordner legen.
+2. `python installer.py` ausführen – das Archiv wird entpackt, Abhängigkeiten werden installiert und Startdateien (`start.*`) werden angelegt.
+3. Starten:
+   - Windows: `start.bat`
+   - macOS/Linux: `./start.sh` oder `python start.py`
+
 ## Modelle & Preise
 Die Preise stammen aus Ihrer Vorgabe und sind in `config.toml` hinterlegt. Falls Ihr Account / Ihr Modell andere Preise hat, passen Sie sie bitte dort an. Die Kostenschätzung basiert auf
 geschätzten Eingabe‑/Ausgabe‑Tokens und differenziert zwischen *Eingabe*, *Zwischengespeicherte Eingabe* und *Ausgabe*. Für die meisten Workloads wird *Eingabe*+*Ausgabe* angesetzt.

--- a/installer.py
+++ b/installer.py
@@ -1,0 +1,72 @@
+import os
+import zipfile
+import subprocess
+import sys
+import platform
+import stat
+
+ZIP_NAME = "Lernkarten.zip"
+EXTRACT_DIR = "Lernkarten"
+
+
+def ensure_extracted():
+    if os.path.isdir(EXTRACT_DIR):
+        print("[INFO] Archiv bereits entpackt.")
+        return
+    if not os.path.exists(ZIP_NAME):
+        print(f"[FEHLER] {ZIP_NAME} nicht gefunden.")
+        sys.exit(1)
+    print("[INFO] Entpacke Archiv …")
+    with zipfile.ZipFile(ZIP_NAME, "r") as zf:
+        zf.extractall(EXTRACT_DIR)
+
+
+def run_install():
+    install_path = os.path.join(EXTRACT_DIR, "install.py")
+    if not os.path.exists(install_path):
+        print("[FEHLER] install.py nicht gefunden im entpackten Verzeichnis.")
+        sys.exit(1)
+    subprocess.check_call([sys.executable, install_path])
+
+
+def create_start_scripts():
+    base_dir = EXTRACT_DIR
+    start_py = f"""#!/usr/bin/env python3
+import os, subprocess, platform
+BASE = os.path.join(os.path.dirname(__file__), {base_dir!r})
+if platform.system() == 'Windows':
+    subprocess.check_call(['cmd', '/c', os.path.join(BASE, 'run.bat')])
+else:
+    subprocess.check_call(['bash', os.path.join(BASE, 'run.sh')])
+"""
+    with open("start.py", "w", encoding="utf-8") as fh:
+        fh.write(start_py)
+    os.chmod("start.py", stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                             stat.S_IRGRP | stat.S_IXGRP |
+                             stat.S_IROTH | stat.S_IXOTH)
+
+    if platform.system() == "Windows":
+        with open("start.bat", "w", encoding="utf-8") as fh:
+            fh.write("@echo off\r\n")
+            fh.write(f"cd {base_dir}\r\n")
+            fh.write("call run.bat\r\n")
+        print("\n[OK] Installation fertig. Starten Sie das Programm mit start.bat")
+    else:
+        with open("start.sh", "w", encoding="utf-8") as fh:
+            fh.write("#!/usr/bin/env bash\n")
+            fh.write(f"cd '{base_dir}'\n")
+            fh.write("bash run.sh\n")
+        os.chmod("start.sh", stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                             stat.S_IRGRP | stat.S_IXGRP |
+                             stat.S_IROTH | stat.S_IXOTH)
+        print("\n[OK] Installation fertig. Starten Sie das Programm mit ./start.sh oder python start.py")
+
+
+def main():
+    ensure_extracted()
+    run_install()
+    create_start_scripts()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document and ignore archive distribution artifacts
- add installer script that unpacks Lernkarten.zip, installs dependencies and writes start scripts

## Testing
- `python -m py_compile $(git ls-files '*.py') installer.py`


------
https://chatgpt.com/codex/tasks/task_e_6896105754bc83309ace6d29147880de