### PR TITLE
Add comprehensive inline documentation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,7 @@
-# empty to mark package
+"""Initialisiert das `app`-Paket.
+
+Dieses Paket bündelt sämtliche Kernmodule der Anwendung: Chunking,
+OpenAI-Anbindung, PDF-Verarbeitung, GUI usw. Das Vorhandensein dieser Datei
+markiert den Ordner als Python-Paket."""
+
+# Keine weiteren Inhalte erforderlich.

--- a/app/chunking.py
+++ b/app/chunking.py
@@ -1,3 +1,14 @@
+"""Utility-Funktionen zur Textsegmentierung.
+
+`split_into_chunks` zerlegt längere Texte in überlappende Abschnitte, die als
+"Chunks" an die OpenAI-API gesendet werden. Die Standardwerte orientieren sich
+an den Einstellungen in `config.toml` (`[chunking]`). Änderungen dort wirken
+sich direkt auf die Parameter `target_tokens`, `overlap_tokens` und
+`max_chars_per_chunk` aus.
+
+Dieses Modul wird hauptsächlich von `pipeline.load_and_segment` verwendet.
+"""
+
 from .models import count_tokens_rough
 import re, math
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,10 @@
-# app/config.py
+"""Hilfsfunktionen zum Laden der zentralen Konfigurationsdatei.
+
+Das Modul kapselt den Zugriff auf ``config.toml`` und stellt Standardwerte für
+Modelle, Preise und Heuristiken bereit. `load_config` wird u.a. von
+`app.pipeline`, `app.openai_client` und der GUI verwendet, um Einstellungen wie
+Modelle, Sprache oder Chunking-Parameter zu beziehen.
+"""
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict

--- a/app/cost.py
+++ b/app/cost.py
@@ -1,3 +1,11 @@
+"""Kostenabschätzung auf Basis der Konfiguration.
+
+Dieses Modul wird nicht direkt von der Pipeline genutzt, dient jedoch als
+Beispiel, wie sich die Modelleinstellungen und Chunking-Parameter auf die
+erwarteten API-Kosten auswirken. Es liest die Preise aus ``config.toml`` und
+greift für Token-Zählungen auf `app.models` sowie `app.chunking` zurück.
+"""
+
 from .models import count_tokens_rough
 from .config import load_config
 from .chunking import split_into_chunks

--- a/app/excel_export.py
+++ b/app/excel_export.py
@@ -1,12 +1,22 @@
-# app/excel_export.py
+"""Export-Helfer zum Schreiben der generierten Karten in eine Excel-Datei.
+
+Wird von `pipeline.export_excel` sowie der GUI verwendet. Das Format der
+eingehenden ``rows`` entspricht der Struktur, die `pipeline.generate_cards`
+liefert.
+"""
+
 from __future__ import annotations
 import pandas as pd
 from typing import List, Dict, Any
 
 def to_excel(rows: List[Dict[str, Any]], out_path: str) -> None:
+    """Schreibt eine Liste von Karten in ``out_path``.
+
+    ``rows`` ist eine Liste von Dictionaries wie sie `pipeline.generate_cards`
+    erzeugt. Die Funktion wandelt sie in ein pandas-DataFrame um und speichert
+    dieses als ``.xlsx``.
     """
-    rows: [{"original": str, "fragen": List[str], "antworten": List[str], "labels": List[str], "hinweise": str}, ...]
-    """
+
     df = pd.DataFrame([
         {
             "Original": r.get("original",""),

--- a/app/export.py
+++ b/app/export.py
@@ -1,6 +1,19 @@
+"""Alternative Export-Routinen für Lernkarten.
+
+Im Gegensatz zu `excel_export.to_excel` erzeugt `export_to_excel` zusätzlich
+eine CSV-Datei (für z.B. Anki) sowie eine kleine JSON-Metadatei. Wird aktuell
+nicht direkt in der Pipeline verwendet, steht jedoch als Beispiel zur Verfügung.
+"""
+
 import os, pandas as pd, csv, datetime, pathlib, json
 
-def export_to_excel(rows, out_dir, base_name="export"):
+def export_to_excel(rows, out_dir, base_name: str = "export"):
+    """Schreibt ``rows`` in verschiedene Formate innerhalb von ``out_dir``.
+
+    Neben einer Excel-Datei wird auch eine CSV- und JSON-Datei erzeugt, die
+    Metadaten (Anzahl der Karten) enthält.
+    """
+
     ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     xlsx_path = os.path.join(out_dir, f"{base_name}_{ts}.xlsx")
     df = pd.DataFrame(rows, columns=["Original", "Frage", "Antwort", "Labels", "Quelle"])

--- a/app/gui.py
+++ b/app/gui.py
@@ -1,3 +1,12 @@
+"""Tkinter-basierte Desktop-Oberfläche.
+
+Die GUI verbindet Benutzerinteraktionen mit der Pipeline. Viele
+Standardwerte (z. B. Startsprache, Fragen pro Chunk) stammen aus
+``config.toml`` und werden über `load_config` eingelesen. Sie ruft
+`pipeline.Pipeline` auf, um PDFs einzulesen, OpenAI anzusprechen und die
+Ergebnisse zu exportieren.
+"""
+
 import os
 import threading
 import queue

--- a/app/labeling.py
+++ b/app/labeling.py
@@ -1,3 +1,11 @@
+"""Hilfsfunktionen für die Segment-Klassifikation.
+
+Das Modul verwendet die in `prompts.py` definierten System/User-Prompts und
+ruft `models.call_json_chat` auf, um für einen Textausschnitt Labels wie
+``definition`` oder ``fact`` zu bestimmen. Dies ist eine niedrigere Ebene der
+Pipeline-Klassifikation.
+"""
+
 from .prompts import LABEL_SYSTEM, LABEL_USER
 from .models import call_json_chat
 

--- a/app/logging_utils.py
+++ b/app/logging_utils.py
@@ -1,3 +1,9 @@
+"""Einfache Logger-Konfiguration.
+
+Stellt `get_logger` bereit, das sowohl in der GUI als auch in Skripten für eine
+einheitliche Log-Ausgabe sorgt. Die Logdateien liegen im Unterordner ``.logs``.
+"""
+
 import logging, pathlib, datetime
 
 def get_logger(name="gsa"):

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,10 @@
-# app/main.py
+"""Standalone-Startskript für die alternative Tkinter-Oberfläche.
+
+Während `gui.py` eine vereinfachte Oberfläche bietet, stellt dieses Modul eine
+ausführlichere Variante bereit. Es demonstriert, wie `LernkartenPipeline` direkt
+aus einem Skript heraus verwendet werden kann.
+"""
+
 from __future__ import annotations
 import os, sys, threading, traceback
 from tkinter import Tk, ttk, filedialog, StringVar, IntVar, BooleanVar, Text, END, N, S, E, W

--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,11 @@
+"""Niedriglevel-Utilities für direkte OpenAI-Aufrufe.
+
+Dieses Modul stellt einfache Wrapper für Chat-Completions bereit und bietet
+einen groben Token-Zähler. Es wird von anderen Modulen (z. B. `openai_client`
+oder `labeling`) genutzt, wenn ein direkter API-Zugriff ohne zusätzliche
+Pipeline-Abstraktion nötig ist.
+"""
+
 import os, time, hashlib, json, math
 from typing import Dict, Any
 

--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -1,4 +1,11 @@
-# app/openai_client.py
+"""Höhere Abstraktion der OpenAI-API.
+
+`OpenAIClient` kapselt die eigentlichen API-Aufrufe und kümmert sich um
+Initialisierung, Fehlerbehandlung und JSON-Modus. Die Klassen und Methoden
+werden von `pipeline.LernkartenPipeline` genutzt und greifen auf Werte aus
+``config.toml`` zurück (`DEFAULT_*`).
+"""
+
 from __future__ import annotations
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass

--- a/app/pdf_ingest.py
+++ b/app/pdf_ingest.py
@@ -1,4 +1,11 @@
-# app/pdf_ingest.py
+"""Extraktion und grobe Segmentierung von PDF-Dateien.
+
+`extract_text_from_pdf` versucht zunächst ``pdfplumber`` zu verwenden und fällt
+bei fehlender Installation auf ``pypdf`` zurück. Die Funktion `segment_text`
+nimmt die Rohtexte entgegen und zerlegt sie in Abschnitte, bevor das feinere
+Chunking (`app.chunking`) angewendet wird.
+"""
+
 from __future__ import annotations
 import re
 from typing import List, Tuple, Iterable, Optional

--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -1,3 +1,9 @@
+"""Low-level PDF-Helfer.
+
+Dieses Modul wird von `pdf_ingest` und der GUI genutzt, um Text aus PDF-Dateien
+oder alternativen Quellen zu extrahieren und grob zu bereinigen.
+"""
+
 from pypdf import PdfReader
 import re, os, pathlib
 

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -1,4 +1,11 @@
-# app/pipeline.py
+"""Zentrale Verarbeitungslogik für PDFs → Lernkarten.
+
+Die `LernkartenPipeline` verbindet alle Einzelmodule: PDF-Einlesung,
+Segmentierung, Klassifikation, Frage-Antwort-Erzeugung und Export. Viele
+Standardwerte stammen aus ``config.toml`` und werden beim Erstellen der
+`OpenAISettings` übergeben.
+"""
+
 from __future__ import annotations
 from typing import List, Dict, Any, Tuple, Callable, Optional
 from dataclasses import dataclass
@@ -27,6 +34,12 @@ class LernkartenPipeline:
         self.tok = Tokenizer()
 
     def load_and_segment(self, path: str) -> List[Segment]:
+        """Liest eine PDF ein und segmentiert sie in grobe Abschnitte.
+
+        Die feine Chunking-Logik (`app.chunking`) wird später angewendet; hier
+        erfolgt nur eine heuristische Absatz-Zerlegung über `pdf_ingest.segment_text`.
+        """
+
         raw = extract_text_from_pdf(path)
         chunks = segment_text(raw)
         return [Segment(text=c) for c in chunks]

--- a/app/prompts.py
+++ b/app/prompts.py
@@ -1,3 +1,10 @@
+"""Konstanten mit System- und Nutzerprompts für OpenAI-Aufrufe.
+
+Andere Module (z. B. `labeling` oder `openai_client`) importieren diese Strings,
+um konsistente Prompts zu verwenden. Anpassungen hier wirken sich sofort auf
+alle Aufrufe aus.
+"""
+
 LABEL_SYSTEM = """Sie sind ein präziser akademischer Textklassifizierer.
 Geben Sie ausschließlich JSON zurück:
 {

--- a/app/tokenizer_utils.py
+++ b/app/tokenizer_utils.py
@@ -1,4 +1,10 @@
-# app/tokenizer_utils.py
+"""Tokenisierungs-Helfer.
+
+Stellt eine einfache Heuristik sowie eine optionale `tiktoken`-Integration zur
+Verfügung. Wird von `pipeline` und anderen Modulen genutzt, um die Größe von
+Textabschnitten abzuschätzen.
+"""
+
 from __future__ import annotations
 from typing import Iterable, Optional
 

--- a/config.toml
+++ b/config.toml
@@ -1,24 +1,36 @@
-# Konfiguration für GSA Flashcards
+"""
+Zentrale Anwendungskonfiguration. Sämtliche Einstellungen werden beim Start
+über `app.config.load_config` eingelesen und anschließend an die jeweiligen
+Module weitergereicht. Jede Option ist daher mit einem Hinweis versehen, wo sie
+im Code verwendet wird und welche Alternativen möglich sind.
+"""
 
 [models]
-# Platzhalter-IDs – bitte ggf. anpassen:
-label_model = "gpt-5-nano"
-qa_model    = "gpt-5-mini"   # oder "gpt-5" für höchste Qualität
-use_json_mode = true
-max_parallel_requests = 3
+# IDs der zu verwendenden OpenAI‑Modelle. Sie werden in `app.openai_client`
+# gelesen und bestimmen, welche Endpunkte für Klassifikation und Fragenantworten
+# angesprochen werden.
+label_model = "gpt-5-nano"          # für Segment-Klassifikation in `pipeline.classify`
+qa_model    = "gpt-5-mini"          # Modell für QA-Generierung; "gpt-5" liefert höhere Qualität
+use_json_mode = true                # steuert JSON-Modus in `openai_client`; nötig für strukturierte Antworten
+max_parallel_requests = 3           # maximale gleichzeitige API-Aufrufe in `openai_client`
 
 [chunking]
-target_tokens = 600          # grobe Zielgröße pro Chunk
-overlap_tokens = 60
-max_chars_per_chunk = 4000   # Sicherheitsgrenze, falls Token-Estimator fehlt
+# Steuergrößen für die Textsegmentierung in `app.chunking.split_into_chunks`.
+# Anpassungen wirken sich direkt auf die Größe der an OpenAI gesendeten Textstücke aus.
+target_tokens = 600          # Zielanzahl Tokens pro Chunk; größer = weniger, aber längere API-Calls
+overlap_tokens = 60          # Anzahl Tokens Überlappung zwischen Chunks; erhöht Kontext bei QA
+max_chars_per_chunk = 4000   # harte Obergrenze pro Chunk, falls Token-Schätzer fehlt
 
 [prompting]
-language = "de"              # "de" | "en" | ...
-tone = "sachlich, prüfungsorientiert, präzise"
-max_questions_per_chunk_default = 8
+# Vorgaben für die Fragenerzeugung in `pipeline.generate_cards` und
+# `openai_client.gen_qa_for_chunk`.
+language = "de"              # Sprache der Fragen/Antworten, z.B. "de", "en" oder "fr"
+tone = "sachlich, prüfungsorientiert, präzise"  # zusätzlicher Tonfall für die System-Prompts
+max_questions_per_chunk_default = 8  # Begrenzung, wird von der GUI als Startwert gelesen
 
 [costs]
-# Preise laut Ihrer Vorgabe (USD pro 1 Mio Tokens)
+# Preisangaben (USD pro 1 Mio Tokens) für die Kostenschätzung in
+# `pipeline.estimate_cost`. Werte können bei neuen Modellen angepasst werden.
 # GPT-5
 gpt-5_input_usd_per_mtok = 1250.0
 gpt-5_cached_input_usd_per_mtok = 0.125
@@ -35,4 +47,5 @@ gpt-5-nano_cached_input_usd_per_mtok = 0.005
 gpt-5-nano_output_usd_per_mtok = 400.0
 
 [ui]
+# Darstellungsthema für die Tkinter-Oberfläche in `app.gui`.
 theme = "auto"    # "auto" | "light" | "dark"

--- a/docs/ARCHITEKTUR.md
+++ b/docs/ARCHITEKTUR.md
@@ -1,0 +1,134 @@
+# Architektur und Modulübersicht
+
+Diese Dokumentation beschreibt die wichtigsten Module des Projekts,
+welche anderen Komponenten sie aufrufen und welche Erweiterungen
+möglich sind. Sie richtet sich an Entwickler, die den Lernkarten‐
+Generator anpassen oder erweitern möchten.
+
+## GUI-Einstiegspunkte
+
+### `app/main.py`
+Die Datei `main.py` enthält die aktuelle Tkinter‑GUI. Die Klasse
+`App` kümmert sich um Dateiauswahl, Modelleinstellungen und den
+Start der Pipeline【F:app/main.py†L20-L116】. Über
+`segment_and_estimate` werden PDF‑Texte eingelesen und auf Basis von
+`tokenizer_utils.Tokenizer` sowie `pipeline.LernkartenPipeline`
+Kosten geschätzt【F:app/main.py†L117-L181】. Die Methode
+`start_pipeline` erzeugt einen `LernkartenPipeline`‑Thread, der die
+weitere Verarbeitung übernimmt【F:app/main.py†L182-L241】.
+
+### `app/gui.py`
+`gui.py` stellt eine alternative, ältere GUI bereit. Sie nutzt die
+Klasse `Pipeline` (ältere Variante der Verarbeitung) und die
+Kostenfunktion `cost.estimate_cost_for_text` für eine grobe
+Schätzung【F:app/gui.py†L8-L60】【F:app/gui.py†L96-L132】. Für neue
+Features sollte bevorzugt `main.py` genutzt werden; `gui.py` kann als
+Beispiel für eigene Oberflächen dienen.
+
+## Pipeline und Verarbeitung
+
+### `app/pipeline.py`
+Die Klasse `LernkartenPipeline` bündelt Segmentierung, Klassifikation,
+Fragen‑Generierung und Export【F:app/pipeline.py†L10-L73】.
+Wesentliche Methoden:
+
+- `load_and_segment` ruft `pdf_ingest.extract_text_from_pdf` und
+  `segment_text` auf, um Rohtext in `Segment`‑Objekte zu zerlegen
+  【F:app/pipeline.py†L24-L28】.
+- `classify` nutzt `OpenAIClient.classify_segment` für jedes Segment
+  und erlaubt Abbruch/Pause über Callbacks【F:app/pipeline.py†L31-L50】.
+- `generate_cards` bestimmt pro Segment die Anzahl der Fragen auf
+  Basis der Tokenanzahl (`Tokenizer.count`) und ruft
+  `OpenAIClient.gen_qa_for_chunk` auf【F:app/pipeline.py†L52-L75】.
+- `export_excel` delegiert an `excel_export.to_excel`.
+
+Erweiterungen: neue Exportformate können durch zusätzliche Methoden
+analog zu `export_excel` hinzugefügt werden; weitere Verarbeitungsschritte
+(z. B. Nachbearbeitung der Fragen) lassen sich vor dem Export einbauen.
+
+### `app/openai_client.py`
+Kapselt den Zugriff auf die OpenAI‑API. `classify_segment` liefert pro
+Textabschnitt ein Label und ein `keep`‑Flag, das in `LernkartenPipeline`
+für die Filterung genutzt wird【F:app/openai_client.py†L24-L55】.
+`gen_qa_for_chunk` erzeugt Lernkarten und wird von
+`LernkartenPipeline.generate_cards` aufgerufen【F:app/openai_client.py†L57-L98】.
+Die Modellnamen (`OpenAISettings`) können zentral angepasst werden.
+
+### `app/models.py`
+Enthält generische Hilfsfunktionen für OpenAI‑Aufrufe ohne GUI. Dazu
+gehören Token‑Schätzungen (`count_tokens_rough`) und allgemeine
+Chat‑Wrapper (`call_json_chat`, `call_text_chat`)【F:app/models.py†L15-L52】.
+Diese Funktionen werden u. a. vom Modul `labeling` genutzt.
+
+## PDF- und Textverarbeitung
+
+### `app/pdf_ingest.py`
+Extrahiert Text aus PDF‑Dateien (pdfplumber oder pypdf) und segmentiert
+Absätze heuristisch nach Länge【F:app/pdf_ingest.py†L1-L44】【F:app/pdf_ingest.py†L46-L85】.
+Die Funktion `segment_text` wird sowohl in der GUI als auch in der
+Pipeline verwendet.
+
+### `app/pdf_utils.py`
+Bietet ein alternatives, stärker bereinigendes PDF‑Parsing mit
+Heuristiken für Kopf‑/Fußzeilen und Silbentrennungen【F:app/pdf_utils.py†L1-L27】.
+`try_extract_text` fällt bei TXT‑Dateien auf einfaches Lesen zurück.
+
+### `app/chunking.py`
+Teilt langen Text in überlappende Segmente, um Tokenlimits einzuhalten.
+Die Funktion `split_into_chunks` wird von `cost.estimate_cost_for_text`
+verwendet, um die Anzahl der Chunks für die Kostenschätzung zu
+bestimmen【F:app/chunking.py†L1-L56】. Erweiterungen können z. B. andere
+Heuristiken zur Überschriften‑Erkennung einbringen.
+
+### `app/tokenizer_utils.py`
+Kapselt Tokenzählung mittels `tiktoken` mit Fallback auf eine einfache
+Heuristik【F:app/tokenizer_utils.py†L1-L33】. Wird in der Pipeline und in
+anderen Modulen genutzt, um eine Abhängigkeit von `tiktoken` optional
+zu machen.
+
+## Kosten, Export und Logging
+
+### `app/cost.py`
+Schätzt Kosten, indem `chunking.split_into_chunks` und
+`models.count_tokens_rough` kombiniert werden. Preise werden aus
+`config.toml` geladen; Änderungen an Modellpreisen oder Schätzparametern
+können dort erfolgen【F:app/cost.py†L1-L24】.
+
+### `app/excel_export.py` und `app/export.py`
+`excel_export.to_excel` exportiert generierte Karten in eine einfache
+Excel‑Datei【F:app/excel_export.py†L1-L17】. `export.export_to_excel`
+erzeugt zusätzlich CSV und Metadaten und kann als Vorlage für komplexere
+Exporte dienen【F:app/export.py†L1-L20】.
+
+### `app/logging_utils.py`
+Stellt einen Logger bereit, der sowohl auf die Konsole als auch in eine
+Datei schreibt. Damit kann die Pipeline leicht um detaillierte
+Protokollierung erweitert werden【F:app/logging_utils.py†L1-L10】.
+
+## Prompts und Klassifikation
+
+### `app/prompts.py`
+Definiert System‑ und Nutzer‑Prompts für die Klassifikation und
+Frage‑Generierung【F:app/prompts.py†L1-L30】【F:app/prompts.py†L32-L48】.
+Änderungen an den Prompts wirken sich direkt auf die Antworten der
+OpenAI‑Modelle aus und ermöglichen z. B. andere Zielsprachen oder
+Fragetypen.
+
+### `app/labeling.py`
+`classify_chunk` nutzt `prompts.LABEL_SYSTEM` und `models.call_json_chat`
+für eine eigenständige Klassifikation einzelner Textstücke【F:app/labeling.py†L1-L11】.
+Die Rückgabestruktur enthält Nutzungsdaten, die zur späteren
+Kostenanalyse verwendet werden können.
+
+## Erweiterungshinweise
+
+- **Neue Modelle**: Modellnamen und Preise werden in `config.toml`
+  gepflegt. Für zusätzliche Modelle Preise ergänzen und ggf.
+  `OpenAISettings` erweitern.
+- **Alternative Exporte**: Weitere Formate (z. B. Anki‑Decks) lassen
+  sich ähnlich wie `export.export_to_excel` implementieren.
+- **Zusätzliche Verarbeitung**: Vor oder nach der Frage‑Generierung
+  können Funktionen eingefügt werden, z. B. zur Qualitätskontrolle oder
+  zum Entfernen redundanter Karten.
+- **GUI‑Anpassungen**: `main.py` bietet Einstiegspunkte für zusätzliche
+  Bedienelemente oder Fortschrittsanzeigen.


### PR DESCRIPTION
## Summary
- Detail configuration options with cross-references to consuming modules
- Add module-level docstrings across pipeline, client, GUI and helpers for clarity
- Clarify how text segmentation and generation parameters interact

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689748fce74083309f5e39dff24a1a2a