### PR TITLE
Add unit tests and CI workflow for core utilities

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,12 @@
+from app.chunking import split_into_chunks
+from app.models import count_tokens_rough
+
+
+def test_split_into_chunks_overlap_and_token_limit():
+    sentence = "Dies ist ein ziemlich langer Satz mit vielen Worten und endet hier."
+    text = "HEAD1.\n" + sentence + "\nHEAD2.\n" + sentence
+    chunks = split_into_chunks(text, target_tokens=20, overlap_tokens=17)
+
+    assert len(chunks) == 3
+    assert chunks[1].splitlines()[0].strip() == sentence
+    assert all(count_tokens_rough(c) <= 20 for c in chunks)

--- a/tests/test_pdf_ingest.py
+++ b/tests/test_pdf_ingest.py
@@ -1,0 +1,21 @@
+import pytest
+from app.pdf_ingest import segment_text
+
+
+def test_segment_text_headings_and_blank_lines():
+    text = "EINLEITUNG\nDies ist Absatz 1.\n\n\nANHANG\nAbsatz 2."
+    segments = segment_text(text, min_len=10, max_len=100)
+    assert segments == [
+        "EINLEITUNG\nDies ist Absatz 1.",
+        "ANHANG\nAbsatz 2.",
+    ]
+
+
+def test_segment_text_respects_min_max_length():
+    paragraphs = ["A" * 50, "B" * 50, "C" * 50]
+    text = "\n\n".join(paragraphs)
+    segments = segment_text(text, min_len=100, max_len=120)
+    assert len(segments) == 2
+    first, second = segments
+    assert 100 <= len(first) <= 120
+    assert second == "C" * 50

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,25 @@
+from app.pipeline import LernkartenPipeline
+from app.openai_client import OpenAISettings
+from app.config import GPT5_NANO, GPT5_MINI
+
+
+def test_estimate_cost():
+    settings = OpenAISettings(api_key="test", classify_model=GPT5_NANO, qa_model=GPT5_MINI)
+    pipeline = LernkartenPipeline(settings)
+
+    result = pipeline.estimate_cost(
+        full_text="abc",
+        n_segments=10,
+        seg_avg_tokens=200,
+        questions_per_chunk=3,
+        classify_model=GPT5_NANO,
+        qa_model=GPT5_MINI,
+    )
+
+    assert result["classification"]["input_tokens"] == 3200
+    assert result["classification"]["output_tokens"] == 240
+    assert result["classification"]["usd"] == 0.0003
+    assert result["qa"]["input_tokens"] == 3800
+    assert result["qa"]["output_tokens"] == 6600
+    assert result["qa"]["usd"] == 0.0141
+    assert result["sum_usd"] == 0.0144


### PR DESCRIPTION
## Summary
- add pytest suite for PDF segmentation, chunking overlap, and cost estimation
- configure GitHub Actions workflow to run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68976e816b5c8330ad2667d6669147d8