### PR TITLE
feat: support API key lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ und CSV (z. B. für Anki).
   - macOS/Linux: `bash run.sh`
 4. In der GUI: **Skript wählen**, **API‑Key eingeben**, **Gründlichkeit** & **Budget** setzen, **Schätzen** → **Start**.
 
+### API‑Schlüssel bereitstellen
+
+Der OpenAI‑Key wird standardmäßig nur über die GUI abgefragt und **nicht auf
+der Festplatte gespeichert**. Beim Beenden der Anwendung wird der Wert
+verworfen.
+
+Alternativen:
+
+- Umgebungsvariable `OPENAI_API_KEY`
+- `config.toml` → Abschnitt `[auth]` mit `api_key` oder `api_key_file`
+
+> **Warnung:** Das Ablegen des Schlüssels in Textdateien oder `config.toml`
+> ist unsicher. Die Anwendung gibt beim Start eine Warnung aus, wenn solche
+> Quellen genutzt werden.
+
 ## Ordnerstruktur
 
 - `app/` – Quellcode der Anwendung

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,7 @@ Modelle, Preise und Heuristiken bereit. `load_config` wird u.a. von
 `app.pipeline`, `app.openai_client` und der GUI verwendet, um Einstellungen wie
 Modelle, Sprache oder Chunking-Parameter zu beziehen.
 """
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict
@@ -49,6 +50,10 @@ ESTIMATE = {
 
 _CFG_CACHE: Dict[str, Any] | None = None
 
+from .logging_utils import get_logger
+
+logger = get_logger(__name__)
+
 
 def load_config(path: str | None = None) -> Dict[str, Any]:
     """Load configuration from ``config.toml``.
@@ -71,3 +76,48 @@ def load_config(path: str | None = None) -> Dict[str, Any]:
     except FileNotFoundError:
         _CFG_CACHE = {}
     return _CFG_CACHE
+
+
+def load_api_key(cfg: Dict[str, Any] | None = None) -> tuple[str, str]:
+    """Resolve the OpenAI API key from various sources.
+
+    Priority order:
+    1. Environment variable ``OPENAI_API_KEY``
+    2. ``auth.api_key`` in ``config.toml``
+    3. ``auth.api_key_file`` pointing to a text file with the key
+
+    Returns a tuple ``(key, source)`` where ``source`` is one of
+    ``"env"``, ``"config"``, ``"file"`` or ``""`` if no key was found.
+    When loading from config or file, a warning is logged about the
+    security implications.
+    """
+
+    key = os.environ.get("OPENAI_API_KEY")
+    if key:
+        return key.strip(), "env"
+
+    if cfg is None:
+        cfg = load_config()
+    auth = cfg.get("auth", {})
+
+    cfg_key = auth.get("api_key")
+    if cfg_key:
+        logger.warning(
+            "API key loaded from config.toml. Storing secrets on disk is unsafe."
+        )
+        return str(cfg_key).strip(), "config"
+
+    key_file = auth.get("api_key_file")
+    if key_file:
+        path = Path(key_file).expanduser()
+        try:
+            file_key = path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            logger.warning("Could not read API key file %s: %s", path, exc)
+            return "", ""
+        logger.warning(
+            "API key loaded from file %s. Plain-text storage poses risks.", path
+        )
+        return file_key, "file"
+
+    return "", ""

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,11 @@ Module weitergereicht. Jede Option ist daher mit einem Hinweis versehen, wo sie
 im Code verwendet wird und welche Alternativen möglich sind.
 """
 
+[auth]
+# Optionale API-Key-Quelle. Klartextspeicherung ist riskant!
+# api_key = "sk-..."
+# api_key_file = "pfad/zur/api_key.txt"
+
 [models]
 # IDs der zu verwendenden OpenAI‑Modelle. Sie werden in `app.openai_client`
 # gelesen und bestimmen, welche Endpunkte für Klassifikation und Fragenantworten

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,28 @@
+from app.config import load_api_key
+
+def test_env_precedence(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "envkey")
+    cfg = {"auth": {"api_key": "cfgkey"}}
+    key, source = load_api_key(cfg)
+    assert key == "envkey"
+    assert source == "env"
+
+
+def test_config_key_warning(caplog):
+    cfg = {"auth": {"api_key": "cfgkey"}}
+    caplog.set_level("WARNING")
+    key, source = load_api_key(cfg)
+    assert key == "cfgkey"
+    assert source == "config"
+    assert any("config.toml" in r.message for r in caplog.records)
+
+
+def test_file_key_warning(tmp_path, caplog):
+    fp = tmp_path / "key.txt"
+    fp.write_text("filekey", encoding="utf-8")
+    cfg = {"auth": {"api_key_file": str(fp)}}
+    caplog.set_level("WARNING")
+    key, source = load_api_key(cfg)
+    assert key == "filekey"
+    assert source == "file"
+    assert any("file" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add `load_api_key` helper reading env vars, config or file with warnings
- prefill GUIs with resolved key, display safety notices, and wipe key on exit
- document API key options and risks; add tests for key resolution

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68976d4caab48330a9ac4d31bb3ce65f