### PR TITLE
Ensure progress callback reports skipped segments

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -82,6 +82,8 @@ class LernkartenPipeline:
         total = len(segments)
         for i, s in enumerate(segments, 1):
             if not s.keep:
+                if progress_cb:
+                    progress_cb(i, total, card_count)
                 continue
             if stop_cb and stop_cb():
                 raise RuntimeError("Abgebrochen")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from app.pipeline import LernkartenPipeline
+from app.pipeline import LernkartenPipeline, Segment
 from app.openai_client import OpenAISettings
 from app.config import GPT5_NANO, GPT5_MINI
 
@@ -23,3 +23,35 @@ def test_estimate_cost():
     assert result["qa"]["output_tokens"] == 6600
     assert result["qa"]["usd"] == 0.0141
     assert result["sum_usd"] == 0.0144
+
+
+def test_generate_cards_reports_all_segments(monkeypatch):
+    settings = OpenAISettings(api_key="test")
+    pipeline = LernkartenPipeline(settings)
+
+    monkeypatch.setattr(pipeline.tok, "count", lambda text: 100)
+    monkeypatch.setattr(
+        pipeline.client,
+        "gen_qa_for_chunk",
+        lambda text, n_questions, language: [{"frage": "f", "antwort": "a"}] * n_questions,
+    )
+
+    segments = [
+        Segment("eins"),
+        Segment("zwei", keep=False),
+        Segment("drei"),
+    ]
+    calls = []
+
+    def progress(i, total, cards):
+        calls.append((i, total, cards))
+
+    pipeline.generate_cards(
+        segments,
+        max_questions_per_chunk=2,
+        language="de",
+        progress_cb=progress,
+    )
+
+    assert [c[0] for c in calls] == [1, 2, 3]
+    assert len(calls) == len(segments)


### PR DESCRIPTION
## Summary
- Always invoke `progress_cb` for each segment in `generate_cards`, including skipped ones
- Add regression test verifying progress callbacks fire for all segments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68978562a72083309c2b3d9ebfb0fc0c