### PR TITLE
Skip adding empty QA rows

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -94,6 +94,10 @@ class LernkartenPipeline:
             items = self.client.gen_qa_for_chunk(
                 s.text[:8000], n_questions, language=language
             )
+            if not items:
+                if progress_cb:
+                    progress_cb(i, total, card_count)
+                continue
             card_count += len(items)
             rows.append(
                 {

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -55,3 +55,25 @@ def test_generate_cards_reports_all_segments(monkeypatch):
 
     assert [c[0] for c in calls] == [1, 2, 3]
     assert len(calls) == len(segments)
+
+
+def test_generate_cards_skips_empty_items(monkeypatch):
+    settings = OpenAISettings(api_key="test")
+    pipeline = LernkartenPipeline(settings)
+
+    monkeypatch.setattr(pipeline.tok, "count", lambda text: 100)
+    monkeypatch.setattr(
+        pipeline.client,
+        "gen_qa_for_chunk",
+        lambda text, n_questions, language: [],
+    )
+
+    segments = [Segment("eins")]
+
+    rows = pipeline.generate_cards(
+        segments,
+        max_questions_per_chunk=2,
+        language="de",
+    )
+
+    assert rows == []


### PR DESCRIPTION
## Summary
- Avoid adding rows when QA generation returns no items
- Test that empty QA responses produce no rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897864e84a48330a4affa93eaf71216