### PR TITLE
Add jitter to OpenAI retry with test

### DIFF
--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -11,6 +11,7 @@ from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 import time
 import json
+import random
 
 from openai import OpenAIError
 
@@ -30,7 +31,9 @@ def retry_request(func, *args, **kwargs):
             Kontrollparameter:
             - n: maximale Anzahl Versuche (Standard: 3)
             - delay: Anfangspause zwischen den Versuchen in Sekunden
-              (Standard: 1)
+              (Standard: 1). Zwischen den Versuchen wird zusätzlich ein
+              zufälliger Jitter von 0 bis 1 Sekunde addiert, um
+              gleichzeitige Wiederholungen zu entzerren.
             - backoff: Faktor, mit dem die Pause nach jedem Fehlschlag
               multipliziert wird (Standard: 2)
     """
@@ -57,7 +60,7 @@ def retry_request(func, *args, **kwargs):
                 exc,
                 delay,
             )
-            time.sleep(delay)
+            time.sleep(delay + random.uniform(0, 1))
             delay *= backoff
 
 @dataclass

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,20 @@
+import app.openai_client as oc
+
+
+def test_retry_request_uses_jitter(monkeypatch):
+    sleep_calls = []
+
+    monkeypatch.setattr(oc.time, "sleep", lambda s: sleep_calls.append(s))
+    monkeypatch.setattr(oc.random, "uniform", lambda a, b: 0.5)
+
+    attempts = {"count": 0}
+
+    def flaky():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise oc.OpenAIError("fail")
+        return "ok"
+
+    result = oc.retry_request(flaky, n=2, delay=1, backoff=2)
+    assert result == "ok"
+    assert sleep_calls == [1.5]


### PR DESCRIPTION
## Summary
- add random jitter to API retry delays to stagger calls
- document jitter behaviour for retry_request
- test retry_request jitter using monkeypatch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689787463d788330a9820281d7ad4b63