### PR TITLE
Handle missing or invalid config in editor

### DIFF
--- a/config_editor.py
+++ b/config_editor.py
@@ -16,7 +16,14 @@ class ConfigEditor(tk.Tk):
         gear_button.pack(expand=True)
 
     def open_editor(self) -> None:
-        cfg = toml.load(CONFIG_PATH)
+        try:
+            cfg = toml.load(CONFIG_PATH)
+        except (FileNotFoundError, toml.TomlDecodeError):
+            cfg = {}
+            messagebox.showwarning(
+                "Warnung",
+                "Konfiguration konnte nicht geladen werden. Es wird eine leere Konfiguration verwendet.",
+            )
 
         top = tk.Toplevel(self)
         top.title("Einstellungen")


### PR DESCRIPTION
## Summary
- Warn the user and fallback to an empty config if `config.toml` is missing or invalid

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689791bb78688330bebdcfbd7298d179