### PR TITLE
Remove requests dependency from tokenization and model utilities

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -9,7 +9,6 @@ Pipeline-Abstraktion nötig ist.
 import os, time, hashlib, json, math
 from typing import Dict, Any
 
-import requests
 
 def _get_openai_client():
     # Import on demand to avoid hard dependency at import time
@@ -33,7 +32,7 @@ def count_tokens_rough(text: str) -> int:
         import tiktoken
         enc = tiktoken.get_encoding("cl100k_base")
         return len(enc.encode(text))
-    except (ImportError, ValueError, requests.exceptions.RequestException):
+    except Exception:
         return max(1, math.ceil(len(text) / 4))
 
 def call_json_chat(model: str, system_prompt: str, user_prompt: str, temperature: float = 0.1, max_output_tokens: int = 600) -> Dict[str, Any]:

--- a/app/tokenizer_utils.py
+++ b/app/tokenizer_utils.py
@@ -8,8 +8,6 @@ Textabschnitten abzuschätzen.
 from __future__ import annotations
 from typing import Iterable, Optional
 
-import requests
-
 from .logging_utils import get_logger
 
 logger = get_logger(__name__)
@@ -34,10 +32,10 @@ class Tokenizer:
             # o200k_base abwaerts-kompatibel; faellt auf cl100k_base zurueck
             try:
                 self._enc = tiktoken.get_encoding(encoding_name)
-            except (KeyError, requests.exceptions.RequestException):
+            except Exception:
                 try:
                     self._enc = tiktoken.get_encoding("cl100k_base")
-                except (KeyError, requests.exceptions.RequestException):
+                except Exception:
                     self._enc = None
         except ImportError:
             self._enc = None


### PR DESCRIPTION
## Summary
- drop `requests` imports from tokenization and model helpers
- replace `requests.exceptions.RequestException` handling with generic `Exception`
- verify repository contains no other `requests` references

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689793a8000883308657304d20ece2f0