### PR TITLE
Handle missing pandas in Excel export

### DIFF
--- a/app/excel_export.py
+++ b/app/excel_export.py
@@ -6,7 +6,6 @@ liefert.
 """
 
 from __future__ import annotations
-import pandas as pd
 from typing import List, Dict, Any
 
 def to_excel(rows: List[Dict[str, Any]], out_path: str) -> None:
@@ -16,6 +15,13 @@ def to_excel(rows: List[Dict[str, Any]], out_path: str) -> None:
     erzeugt. Die Funktion wandelt sie in ein pandas-DataFrame um und speichert
     dieses als ``.xlsx``.
     """
+
+    try:
+        import pandas as pd
+    except ImportError as exc:
+        raise RuntimeError(
+            "Das Paket 'pandas' wird zum Export in Excel-Dateien benötigt."
+        ) from exc
 
     df = pd.DataFrame([
         {


### PR DESCRIPTION
## Summary
- Import pandas lazily inside `to_excel` with a helpful RuntimeError if it's missing

## Testing
- `pytest`
- `python -S - <<'PY'\nimport app.excel_export\nprint('module imported')\nPY`
- `python -S - <<'PY'\nfrom app import excel_export\ntry:\n    excel_export.to_excel([], 'out.xlsx')\nexcept RuntimeError as e:\n    print('RuntimeError:', e)\nPY`


------
https://chatgpt.com/codex/tasks/task_e_689794d3cb5c8330a79f1915ea3e6742