### PR TITLE
refactor: consolidate pdf utilities

### DIFF
--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -1,28 +1,7 @@
-"""Low-level PDF-Helfer.
+"""Thin wrapper – bitte direkt :mod:`app.pdf_ingest` verwenden."""
 
-Dieses Modul wird von der GUI genutzt, um Text aus PDF-Dateien oder
-alternativen Quellen zu extrahieren.
-"""
+from .pdf_ingest import extract_text_from_pdf as try_extract_text
 
-from . import pdf_ingest
-from .logging_utils import get_logger
-
-logger = get_logger(__name__)
-
-
-def extract_text_from_pdf(path):
-    """Delegiere die Extraktion an :mod:`pdf_ingest`."""
-    return pdf_ingest.extract_text_from_pdf(path)
-
-
-def try_extract_text(path):
-    path = str(path)
-    if path.lower().endswith(".pdf"):
-        return extract_text_from_pdf(path)
-    else:
-        try:
-            with open(path, "r", encoding="utf-8", errors="ignore") as f:
-                return f.read()
-        except OSError as exc:
-            logger.warning("Could not read text file %s: %s", path, exc)
-            return ""
+# Backwards-compat: bisher wurde in der GUI ``try_extract_text`` importiert.
+# Exportiere denselben Namen aus ``pdf_ingest``, damit alte Imports weiterlaufen.
+__all__ = ["try_extract_text"]


### PR DESCRIPTION
## Summary
- simplify pdf_utils to a thin wrapper around pdf_ingest
- re-export `try_extract_text` to preserve backward compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a388c3dc8330a130e1db26a29c63