### PR TITLE
Alias old Pipeline to LernkartenPipeline

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -170,3 +170,7 @@ class LernkartenPipeline:
 
     def export_excel(self, rows: List[Dict[str, Any]], out_path: str) -> None:
         to_excel(rows, out_path)
+
+
+# Übergangs-Alias für alte Imports, bitte mittelfristig entfernen:
+Pipeline = LernkartenPipeline


### PR DESCRIPTION
## Summary
- add transitional alias `Pipeline = LernkartenPipeline` to avoid breaking legacy imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a59f3cb88330a4df31be99597553