### PR TITLE
Refine OpenAI client retry logic

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -4,7 +4,7 @@ import app.openai_client as oc
 def test_retry_request_uses_jitter(monkeypatch):
     sleep_calls = []
 
-    monkeypatch.setattr(oc.time, "sleep", lambda s: sleep_calls.append(s))
+    monkeypatch.setattr(oc, "sleep", lambda s: sleep_calls.append(s))
     monkeypatch.setattr(oc.random, "uniform", lambda a, b: 0.5)
 
     attempts = {"count": 0}
@@ -17,4 +17,4 @@ def test_retry_request_uses_jitter(monkeypatch):
 
     result = oc.retry_request(flaky, n=2, delay=1, backoff=2)
     assert result == "ok"
-    assert sleep_calls == [1.5]
+    assert sleep_calls == [0.5]


### PR DESCRIPTION
## Summary
- limit retry handling to OpenAI API errors
- add full jitter exponential backoff via `random.uniform(0, delay)`
- adjust tests for updated jitter behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a7491aec8330ae9accc56d72fc5e