### PR TITLE
Use dataclasses for QA items and card rows

### DIFF
--- a/app/excel_export.py
+++ b/app/excel_export.py
@@ -6,14 +6,16 @@ liefert.
 """
 
 from __future__ import annotations
-from typing import List, Dict, Any
+from typing import List
 from pathlib import Path
 try:
     import pandas as pd  # optional
 except Exception:  # ImportError + env specifics
     pd = None
 
-def to_excel(rows: List[Dict[str, Any]], out_path: str) -> None:
+from .pipeline_models import CardRow
+
+def to_excel(rows: List[CardRow], out_path: str) -> None:
     """Schreibt eine Liste von Karten in ``out_path``."""
 
     path = Path(out_path)
@@ -26,14 +28,14 @@ def to_excel(rows: List[Dict[str, Any]], out_path: str) -> None:
 
     data = [
         {
-            "Original": r.get("original", ""),
+            "Original": r.original,
             "Frage": q,
             "Antwort": a,
-            "Labels": ", ".join(r.get("labels", [])),
-            "Quelle": r.get("source", ""),
+            "Labels": ", ".join(r.labels),
+            "Quelle": r.source,
         }
         for r in rows
-        for q, a in zip(r.get("fragen", []), r.get("antworten", []))
+        for q, a in zip(r.fragen, r.antworten)
     ]
 
     if pd is not None:

--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -13,6 +13,8 @@ from time import sleep
 import json
 import random
 
+from .pipeline_models import QAItem
+
 try:
     from openai import OpenAIError
 except ImportError:  # pragma: no cover - optional dependency
@@ -127,10 +129,10 @@ class OpenAIClient:
             data = {"label": "Fakt", "keep": True, "reason": "fallback"}
         return data
 
-    def gen_qa_for_chunk(self, text: str, n_questions: int, language: str = DEFAULT_LANGUAGE) -> List[Dict[str, str]]:
+    def gen_qa_for_chunk(self, text: str, n_questions: int, language: str = DEFAULT_LANGUAGE) -> List[QAItem]:
         """
         Erzeugt n_questions Lernkarten (Frage/Antwort) fuer den gegebenen Text.
-        Rueckgabe: [{"frage": "...", "antwort": "..."}, ...]
+        Rueckgabe: [QAItem(frage="...", antwort="..."), ...]
         """
         client = self._get_client()
         system = (
@@ -162,12 +164,12 @@ class OpenAIClient:
                 items = data["items"]
             else:
                 items = data
-            out = []
+            out: List[QAItem] = []
             for it in items:
                 q = (it.get("frage") or it.get("question") or "").strip()
                 a = (it.get("antwort") or it.get("answer") or "").strip()
                 if q and a:
-                    out.append({"frage": q, "antwort": a})
+                    out.append(QAItem(frage=q, antwort=a))
             return out
         except (json.JSONDecodeError, KeyError, TypeError):
             logger.warning("Failed to parse QA response: %r", content)

--- a/app/pipeline_models.py
+++ b/app/pipeline_models.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Segment:
+    text: str
+    keep: bool = True
+
+
+@dataclass
+class QAItem:
+    frage: str
+    antwort: str
+    labels: list[str] | None = None
+
+
+@dataclass
+class CardRow:
+    original: str
+    fragen: List[str]
+    antworten: List[str]
+    labels: List[str]
+    source: str = ""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,7 @@
-from app.pipeline import LernkartenPipeline, Segment
+from app.pipeline import LernkartenPipeline
 from app.openai_client import OpenAISettings
 from app.config import GPT5_NANO, GPT5_MINI
+from app.pipeline_models import Segment, QAItem, CardRow
 
 
 def test_estimate_cost():
@@ -33,7 +34,7 @@ def test_generate_cards_reports_all_segments(monkeypatch):
     monkeypatch.setattr(
         pipeline.client,
         "gen_qa_for_chunk",
-        lambda text, n_questions, language: [{"frage": "f", "antwort": "a"}] * n_questions,
+        lambda text, n_questions, language: [QAItem("f", "a")] * n_questions,
     )
 
     segments = [
@@ -46,7 +47,7 @@ def test_generate_cards_reports_all_segments(monkeypatch):
     def progress(i, total, cards):
         calls.append((i, total, cards))
 
-    pipeline.generate_cards(
+    rows = pipeline.generate_cards(
         segments,
         max_questions_per_chunk=2,
         language="de",
@@ -55,6 +56,7 @@ def test_generate_cards_reports_all_segments(monkeypatch):
 
     assert [c[0] for c in calls] == [1, 2, 3]
     assert len(calls) == len(segments)
+    assert all(isinstance(r, CardRow) for r in rows)
 
 
 def test_generate_cards_skips_empty_items(monkeypatch):


### PR DESCRIPTION
## Summary
- Add shared data models `Segment`, `QAItem`, and `CardRow`
- Return structured `CardRow` objects from `LernkartenPipeline.generate_cards`
- Update OpenAI client and Excel export to work with the new dataclasses
- Adjust tests to use dataclass-based QA items and card rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a94adc5883308a559cb96c06fec4