### PR TITLE
Add minimal config validation with editor feedback

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,39 @@ ESTIMATE = {
 }
 
 
+REQUIRED_KEYS = ["models", "costs", "chunking", "ui"]
+_REQUIRED_MODEL_KEYS = ["qa_model", "label_model"]
+
+
+def validate_config(cfg: Dict[str, Any]) -> None:
+    """Validate minimal schema of ``config.toml``.
+
+    Raises ``ValueError`` with a descriptive message if required sections or
+    options are missing. Only a subset of fields is checked to provide early
+    feedback when editing the configuration.
+    """
+
+    for section in REQUIRED_KEYS:
+        if section not in cfg:
+            raise ValueError(f"config.toml: Abschnitt [{section}] fehlt")
+
+    models = cfg["models"]
+    for key in _REQUIRED_MODEL_KEYS:
+        if key not in models:
+            raise ValueError(f"config.toml: Option models.{key} fehlt")
+
+    costs = cfg["costs"]
+    for model in {models["qa_model"], models["label_model"]}:
+        for suffix in (
+            "input_usd_per_mtok",
+            "cached_input_usd_per_mtok",
+            "output_usd_per_mtok",
+        ):
+            cost_key = f"{model}_{suffix}"
+            if cost_key not in costs:
+                raise ValueError(f"config.toml: Kostenangabe costs.{cost_key} fehlt")
+
+
 _CFG_CACHE: Dict[str, Any] | None = None
 
 from .logging_utils import get_logger

--- a/config_editor.py
+++ b/config_editor.py
@@ -3,6 +3,8 @@ from tkinter import ttk, messagebox
 from pathlib import Path
 import toml
 
+from app.config import validate_config
+
 CONFIG_PATH = Path(__file__).resolve().parent / "config.toml"
 
 class ConfigEditor(tk.Tk):
@@ -18,6 +20,11 @@ class ConfigEditor(tk.Tk):
     def open_editor(self) -> None:
         try:
             cfg = toml.load(CONFIG_PATH)
+            try:
+                validate_config(cfg)
+            except ValueError as exc:
+                messagebox.showwarning("Warnung", f"Ungültige Konfiguration: {exc}")
+                cfg = {}
         except (FileNotFoundError, toml.TomlDecodeError):
             cfg = {}
             messagebox.showwarning(

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,38 @@
+import pytest
+
+from app.config import validate_config
+
+
+def _valid_cfg():
+    return {
+        "models": {"qa_model": "gpt-5-mini", "label_model": "gpt-5-nano"},
+        "costs": {
+            "gpt-5-mini_input_usd_per_mtok": 0,
+            "gpt-5-mini_cached_input_usd_per_mtok": 0,
+            "gpt-5-mini_output_usd_per_mtok": 0,
+            "gpt-5-nano_input_usd_per_mtok": 0,
+            "gpt-5-nano_cached_input_usd_per_mtok": 0,
+            "gpt-5-nano_output_usd_per_mtok": 0,
+        },
+        "chunking": {},
+        "ui": {},
+    }
+
+
+def test_validate_config_accepts_valid():
+    validate_config(_valid_cfg())
+
+
+def test_missing_section_raises():
+    cfg = _valid_cfg()
+    cfg.pop("models")
+    with pytest.raises(ValueError, match=r"\[models\] fehlt"):
+        validate_config(cfg)
+
+
+def test_missing_price_raises():
+    cfg = _valid_cfg()
+    cfg["costs"].pop("gpt-5-mini_input_usd_per_mtok")
+    with pytest.raises(ValueError, match="costs.gpt-5-mini_input_usd_per_mtok"):
+        validate_config(cfg)
+


### PR DESCRIPTION
## Summary
- add `validate_config` to check required sections, models and pricing fields in config.toml
- show validation errors in the Tk editor instead of loading corrupt configs
- cover config validation with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897ab0e467c83309a83419a56c5eb51