### PR TITLE
ci: add lint and type checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: Install dependencies
-        run: pip install pytest
-      - name: Run tests
-        run: pytest
+      - name: Install deps
+        run: pip install -U pip pytest ruff mypy coverage
+      - name: Lint
+        run: ruff check app tests
+      - name: Type check
+        run: mypy app
+      - name: Tests (coverage)
+        run: coverage run -m pytest && coverage xml && coverage report -m

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ Lernkarten.zip
 start.sh
 start.bat
 start.py
+.coverage
+coverage.xml
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/


### PR DESCRIPTION
## Summary
- run Ruff lint, MyPy type checking, and Coverage in CI
- ignore coverage and cache artifacts

## Testing
- `ruff check app tests` (fails: unused imports and other lints)
- `mypy app` (fails: missing stubs and attribute errors)
- `coverage run -m pytest && coverage xml && coverage report -m`

------
https://chatgpt.com/codex/tasks/task_e_6897ac0ad3c88330ad2b3d2d71c3ef1e