### PR TITLE
Add ttkbootstrap dependency for theming

### DIFF
--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -5,3 +5,4 @@ pandas>=2.0.0
 openpyxl>=3.1.0
 toml>=0.10.2
 regex>=2024.5.15
+ttkbootstrap>=1.10


### PR DESCRIPTION
## Summary
- include ttkbootstrap in installer requirements to enable theming and extra widgets

## Testing
- `pip install -r installer/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b17ee44483309b140d6c8585caf2