### PR TITLE
Add ttkbootstrap theme module with runtime toggle

### DIFF
--- a/app/gui.py
+++ b/app/gui.py
@@ -10,7 +10,8 @@ Ergebnisse zu exportieren.
 import os
 import threading
 import tkinter as tk
-from tkinter import ttk, filedialog, messagebox
+from ttkbootstrap import ttk
+from tkinter import filedialog, messagebox
 
 from openai import OpenAIError
 
@@ -20,6 +21,7 @@ from .cost import estimate_cost_for_text
 from .pdf_utils import try_extract_text
 from .models import count_tokens_rough
 from .logging_utils import get_logger
+from .theme import make_root, attach_theme_toggle, DEFAULT_THEME, ALT_THEME
 
 logger = get_logger(__name__)
 
@@ -31,18 +33,11 @@ def run_gui():
 
     api_key_initial, source = load_api_key(cfg)
 
-    root = tk.Tk()
-    root.title(APP_TITLE)
-    root.geometry("1000x680")
-
-    # Theming
-    style = ttk.Style()
-    try:
-        if cfg["ui"].get("theme", "auto") == "dark":
-            root.tk.call("tk", "scaling", 1.1)
-        style.theme_use("clam")
-    except tk.TclError:
-        pass
+    theme_pref = cfg["ui"].get("theme", "auto")
+    initial_theme = ALT_THEME if theme_pref == "light" else DEFAULT_THEME
+    root = make_root(APP_TITLE, theme=initial_theme)
+    style = root.style
+    attach_theme_toggle(root, style)
 
     # State variables
     api_key_var = tk.StringVar(value=api_key_initial)

--- a/app/theme.py
+++ b/app/theme.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import platform, json, os, atexit
+import ttkbootstrap as tb
+import tkinter as tk
+from ttkbootstrap.tooltip import ToolTip
+
+DEFAULT_THEME = "superhero"   # dunkel / blau
+ALT_THEME = "flatly"          # hell / modern
+
+def make_root(title: str = "GSA Flashcards", theme: str = DEFAULT_THEME) -> tb.Window:
+    _enable_hidpi_awareness()
+    root = tb.Window(title=title, themename=theme)
+    root.minsize(960, 640)                 # genug Platz für 13" Displays
+    _restore_geometry(root)                # letzte Fenstergröße wiederherstellen
+    _persist_geometry_on_exit(root)
+    return root
+
+def attach_theme_toggle(root: tk.Tk, style: tb.Style) -> None:
+    btn = tb.Button(root, text="Dark/Light", bootstyle="secondary-outline")
+    btn.place(relx=1.0, x=-16, y=12, anchor="ne")
+    ToolTip(btn, text="Theme umschalten (Strg+D)")  # kleine UX‑Hilfe
+    def _toggle(*_):
+        cur = style.theme.name
+        style.theme_use(ALT_THEME if cur == DEFAULT_THEME else DEFAULT_THEME)
+    btn.configure(command=_toggle)
+    root.bind("<Control-d>", _toggle)
+
+def _enable_hidpi_awareness():
+    try:
+        if platform.system() == "Windows":
+            import ctypes  # Per‑Monitor DPI Aware (fallback)
+            ctypes.windll.shcore.SetProcessDpiAwareness(1)
+    except Exception:
+        pass
+
+def _restore_geometry(root: tk.Tk):
+    cfg = os.path.join(os.path.expanduser("~"), ".lernkarte_gui.json")
+    try:
+        if os.path.exists(cfg):
+            geo = json.load(open(cfg, "r", encoding="utf-8")).get("geometry")
+            if geo:
+                root.geometry(geo)
+    except Exception:
+        pass
+
+def _persist_geometry_on_exit(root: tk.Tk):
+    cfg = os.path.join(os.path.expanduser("~"), ".lernkarte_gui.json")
+    @atexit.register
+    def _save():
+        try:
+            json.dump({"geometry": root.wm_geometry()}, open(cfg, "w", encoding="utf-8"))
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add reusable `theme` helper for ttkbootstrap dark/light themes, DPI awareness, and window geometry persistence
- integrate theme helper in GUI with runtime theme toggle

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b5c5e65c8330a196e085931b3642