### PR TITLE
feat: add custom purple theme

### DIFF
--- a/app/theme.py
+++ b/app/theme.py
@@ -4,12 +4,19 @@ import ttkbootstrap as tb
 import tkinter as tk
 from ttkbootstrap.tooltip import ToolTip
 
-DEFAULT_THEME = "superhero"   # dunkel / blau
+BASE_THEME = "superhero"      # Ausgangsbasis
+DEFAULT_THEME = "superhero_lila"  # dunkel / blau mit lila Akzent
 ALT_THEME = "flatly"          # hell / modern
+THEME_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets", "superhero_lila.json"))
 
 def make_root(title: str = "GSA Flashcards", theme: str = DEFAULT_THEME) -> tb.Window:
     _enable_hidpi_awareness()
-    root = tb.Window(title=title, themename=theme)
+    root = tb.Window(title=title, themename=BASE_THEME)
+    _load_user_theme(root.style)
+    try:
+        root.style.theme_use(theme)
+    except Exception:
+        root.style.theme_use(BASE_THEME)
     root.minsize(960, 640)                 # genug Platz für 13" Displays
     _restore_geometry(root)                # letzte Fenstergröße wiederherstellen
     _persist_geometry_on_exit(root)
@@ -51,3 +58,9 @@ def _persist_geometry_on_exit(root: tk.Tk):
             json.dump({"geometry": root.wm_geometry()}, open(cfg, "w", encoding="utf-8"))
         except Exception:
             pass
+
+def _load_user_theme(style: tb.Style) -> None:
+    try:
+        style.load_user_themes(THEME_FILE)
+    except Exception:
+        pass

--- a/assets/superhero_lila.json
+++ b/assets/superhero_lila.json
@@ -1,0 +1,27 @@
+{
+    "themes": [
+        {
+            "superhero_lila": {
+                "type": "dark",
+                "colors": {
+                    "primary": "#6C5CE7",
+                    "secondary": "#4e5d6c",
+                    "success": "#5cb85c",
+                    "info": "#5bc0de",
+                    "warning": "#f0ad4e",
+                    "danger": "#d9534f",
+                    "light": "#ABB6C2",
+                    "dark": "#20374C",
+                    "bg": "#2b3e50",
+                    "fg": "#ffffff",
+                    "selectbg": "#526170",
+                    "selectfg": "#ffffff",
+                    "border": "#222222",
+                    "inputfg": "#ebebeb",
+                    "inputbg": "#32465a",
+                    "active": "#2B4155"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add custom `superhero_lila` theme with purple primary color
- load and use the theme as the default dark look

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c206e8e083309d286f3411d68f43