### PR TITLE
refactor: replace messageboxes with toasts

### DIFF
--- a/app/gui.py
+++ b/app/gui.py
@@ -10,12 +10,12 @@ Ergebnisse zu exportieren.
 import os
 import threading
 import tkinter as tk
-from tkinter import filedialog, messagebox
-from tkinter.scrolledtext import ScrolledText
+from tkinter import filedialog
 import webbrowser
 import ttkbootstrap as tb
 from ttkbootstrap.tooltip import ToolTip
 from ttkbootstrap.toast import ToastNotification
+from ttkbootstrap.scrolled import ScrolledText
 
 from openai import OpenAIError
 
@@ -150,7 +150,7 @@ def run_gui():
     right.add(tab_log, text="Log")
     right.add(tab_export, text="Export")
 
-    log_widget = ScrolledText(tab_log, height=12, wrap="word")
+    log_widget = ScrolledText(tab_log, wrap="word")
     log_widget.pack(fill="both", expand=True)
 
     # Status bar
@@ -185,11 +185,11 @@ def run_gui():
     def estimate() -> None:
         p = file_path_var.get().strip()
         if not p:
-            messagebox.showerror("Fehler", "Bitte zunächst eine Datei wählen.")
+            ToastNotification(title="Fehler", message="Bitte zunächst eine Datei wählen.", bootstyle="danger").show_toast()
             return
         raw = try_extract_text(p)
         if not raw.strip():
-            messagebox.showerror("Fehler", "Konnte keinen Text extrahieren.")
+            ToastNotification(title="Fehler", message="Konnte keinen Text extrahieren.", bootstyle="danger").show_toast()
             return
         model = model_var.get()
         label_model = label_model_var.get()
@@ -201,13 +201,13 @@ def run_gui():
     def start() -> None:
         p = file_path_var.get().strip()
         if not p:
-            messagebox.showerror("Fehler", "Bitte Datei wählen.")
+            ToastNotification(title="Fehler", message="Bitte Datei wählen.", bootstyle="danger").show_toast()
             return
         api = api_key_var.get().strip()
         if not api:
             api, _ = load_api_key(cfg)
         if not api:
-            messagebox.showerror("Fehler", "Bitte API‑Key eingeben (nur für diese Sitzung).")
+            ToastNotification(title="Fehler", message="Bitte API‑Key eingeben (nur für diese Sitzung).", bootstyle="danger").show_toast()
             return
         outd = out_dir_var.get().strip() or "."
         os.makedirs(outd, exist_ok=True)
@@ -262,10 +262,11 @@ def run_gui():
     root.bind("<Control-e>", lambda e: open_export())
 
     if source in {"config", "file"}:
-        messagebox.showwarning(
-            APP_TITLE,
-            "API-Key wurde aus einer Datei geladen. Klartextspeicherung ist riskant.",
-        )
+        ToastNotification(
+            title=APP_TITLE,
+            message="API-Key wurde aus einer Datei geladen. Klartextspeicherung ist riskant.",
+            bootstyle="warning",
+        ).show_toast()
 
     root.protocol("WM_DELETE_WINDOW", on_close)
     root.mainloop()

--- a/config_editor.py
+++ b/config_editor.py
@@ -1,5 +1,7 @@
 import tkinter as tk
-from tkinter import ttk, messagebox
+import ttkbootstrap as tb
+from ttkbootstrap import ttk
+from ttkbootstrap.toast import ToastNotification
 from pathlib import Path
 import toml
 
@@ -7,11 +9,11 @@ from app.config import validate_config
 
 CONFIG_PATH = Path(__file__).resolve().parent / "config.toml"
 
-class ConfigEditor(tk.Tk):
+class ConfigEditor(tb.Window):
     def __init__(self) -> None:
         super().__init__()
         self.title("Konfiguration")
-        self.geometry("120x120")
+        self.minsize(120, 120)
 
         # Gear icon button
         gear_button = ttk.Button(self, text="\u2699\ufe0f", command=self.open_editor, width=3)
@@ -23,16 +25,17 @@ class ConfigEditor(tk.Tk):
             try:
                 validate_config(cfg)
             except ValueError as exc:
-                messagebox.showwarning("Warnung", f"Ungültige Konfiguration: {exc}")
+                ToastNotification(title="Warnung", message=f"Ungültige Konfiguration: {exc}", bootstyle="warning").show_toast()
                 cfg = {}
         except (FileNotFoundError, toml.TomlDecodeError):
             cfg = {}
-            messagebox.showwarning(
-                "Warnung",
-                "Konfiguration konnte nicht geladen werden. Es wird eine leere Konfiguration verwendet.",
-            )
+            ToastNotification(
+                title="Warnung",
+                message="Konfiguration konnte nicht geladen werden. Es wird eine leere Konfiguration verwendet.",
+                bootstyle="warning",
+            ).show_toast()
 
-        top = tk.Toplevel(self)
+        top = tb.Toplevel(self)
         top.title("Einstellungen")
 
         # Chunking target_tokens
@@ -67,7 +70,7 @@ class ConfigEditor(tk.Tk):
 
             with CONFIG_PATH.open("w", encoding="utf-8") as f:
                 toml.dump(cfg, f)
-            messagebox.showinfo("Gespeichert", "Konfiguration gespeichert")
+            ToastNotification(title="Gespeichert", message="Konfiguration gespeichert", bootstyle="success").show_toast()
             top.destroy()
 
         save_button = ttk.Button(top, text="Speichern", command=save)

--- a/gui_config_editor.py
+++ b/gui_config_editor.py
@@ -1,5 +1,7 @@
 import tkinter as tk
-from tkinter import ttk, messagebox
+import ttkbootstrap as tb
+from ttkbootstrap import ttk
+from ttkbootstrap.toast import ToastNotification
 from pathlib import Path
 import toml
 
@@ -14,11 +16,11 @@ def load_config() -> dict:
     except (FileNotFoundError, toml.TomlDecodeError):
         return {}
 
-class ConfigEditor(tk.Tk):
+class ConfigEditor(tb.Window):
     def __init__(self) -> None:
         super().__init__()
         self.title("Konfiguration")
-        self.geometry("120x120")
+        self.minsize(120, 120)
 
         # Gear icon button without external image
         gear_button = ttk.Button(self, text="\u2699\ufe0f", command=self.open_editor, width=3)
@@ -27,12 +29,13 @@ class ConfigEditor(tk.Tk):
     def open_editor(self) -> None:
         cfg = load_config()
         if not cfg:
-            messagebox.showwarning(
-                "Hinweis",
-                "config.toml nicht gefunden oder ungültig. Standardwerte werden verwendet.",
-            )
+            ToastNotification(
+                title="Hinweis",
+                message="config.toml nicht gefunden oder ungültig. Standardwerte werden verwendet.",
+                bootstyle="warning",
+            ).show_toast()
 
-        top = tk.Toplevel(self)
+        top = tb.Toplevel(self)
         top.title("Einstellungen")
 
         # Chunking target_tokens
@@ -67,7 +70,7 @@ class ConfigEditor(tk.Tk):
 
             with CONFIG_PATH.open("w", encoding="utf-8") as f:
                 toml.dump(cfg, f)
-            messagebox.showinfo("Gespeichert", "Konfiguration gespeichert")
+            ToastNotification(title="Gespeichert", message="Konfiguration gespeichert", bootstyle="success").show_toast()
             top.destroy()
 
         save_button = ttk.Button(top, text="Speichern", command=save)


### PR DESCRIPTION
## Summary
- use ttkbootstrap `ToastNotification` instead of modal `messagebox`
- drop manual foreground colors and hardcoded widget sizes
- switch to ttkbootstrap `ScrolledText` widgets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c4e0b6c48330938d87c06eed0b1a