### PR TITLE
Add smoke test for entrypoint imports

### DIFF
--- a/tests/test_smoke_imports.py
+++ b/tests/test_smoke_imports.py
@@ -1,0 +1,20 @@
+import importlib
+
+CANDIDATES = [
+    "app.main",
+    "app.gui",
+    "gui_config_editor",
+    "config_editor",
+]
+
+
+def test_import_any_entrypoint() -> None:
+    ok = False
+    for mod in CANDIDATES:
+        try:
+            importlib.import_module(mod)
+            ok = True
+            break
+        except Exception:
+            pass
+    assert ok, f"Keines der Module importierbar: {CANDIDATES}"


### PR DESCRIPTION
## Summary
- add smoke test ensuring that at least one application entrypoint can be imported

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aeaac5cb88330834928b28a122992