### PR TITLE
Add Ruff and pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+extend-select = ["E", "F", "I", "UP", "B"]
+ignore = ["E203"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+python_files = ["test_*.py", "*_test.py", "tests/*.py"]


### PR DESCRIPTION
## Summary
- configure Ruff linting with Python 3.10 targeting, extended rule selection, and E203 ignore
- integrate Pytest options for quiet mode and test discovery patterns

## Testing
- `ruff check .` (fails: Found 155 errors)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aec89f34883309508acebbb02dd49