### PR TITLE
Use real model IDs and document setup checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Segmentieren, automatischem Labeln (Fakten/Beispiele/Definitionen/Aufzählungen/
 Filtern von Überschriften/Vorwort, Erzeugen von Lernkarten/Fragen sowie Export in Excel
 und CSV (z. B. für Anki).
 
-> **Hinweis:** Die hier konfigurierten Modellnamen (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`) sind **Platzhalter**.
-> Bitte passen Sie sie in `config.toml` an die tatsächlich verfügbaren OpenAI‑Modelle an.
+> **Hinweis:** Die in `config.toml` hinterlegten Modellnamen (`gpt-4o`, `gpt-4o-mini`, `o4-mini`) sind **Beispiele**.
+> Passen Sie sie bei Bedarf an die in Ihrem Account verfügbaren OpenAI‑Modelle an.
 
 ## Highlights
 - **GUI** mit Dateiauswahl, API‑Key‑Eingabe (ephemer), Budget‑Grenze, Gründlichkeits‑Slider (4/8/16 Fragen pro Segment), Fortschrittsbalken und Live‑Log.
@@ -29,6 +29,13 @@ und CSV (z. B. für Anki).
  - Windows: `run.bat`
   - macOS/Linux: `chmod +x run.sh && ./run.sh`
 4. In der GUI: **Skript wählen**, **API‑Key eingeben**, **Gründlichkeit** & **Budget** setzen, **Schätzen** → **Start**.
+
+## Quick-Checkliste
+
+- `config.toml` im UTF‑8‑Format (ohne BOM) anlegen; erste Zeile `[auth]`.
+- Modell‑IDs auf reale OpenAI‑Modelle setzen, z. B. `gpt-4o`, `gpt-4o-mini`, `o4-mini`.
+- `pdfplumber` installieren (für zuverlässige PDF‑Textextraktion).
+- Anwendung neu starten (`run.bat` oder `run.sh`).
 
 ### API‑Schlüssel bereitstellen
 

--- a/app/gui.py
+++ b/app/gui.py
@@ -49,8 +49,8 @@ def run_gui():
     out_dir_var = tk.StringVar(value=os.path.abspath("."))
     thorough_var = tk.IntVar(value=int(cfg["prompting"].get("max_questions_per_chunk_default", 8)))
     budget_var = tk.DoubleVar(value=2.0)
-    model_var = tk.StringVar(value=cfg["models"].get("qa_model", "gpt-5-mini"))
-    label_model_var = tk.StringVar(value=cfg["models"].get("label_model", "gpt-5-nano"))
+    model_var = tk.StringVar(value=cfg["models"].get("qa_model", "gpt-4o"))
+    label_model_var = tk.StringVar(value=cfg["models"].get("label_model", "gpt-4o-mini"))
     use_cache_var = tk.BooleanVar(value=True)
     limit_by_budget_var = tk.BooleanVar(value=True)
     status_var = tk.StringVar(value="Bereit")
@@ -103,11 +103,11 @@ def run_gui():
     row += 1
 
     tb.Label(left, text="Label‑Modell").grid(row=row, column=0, sticky="w")
-    tb.Combobox(left, textvariable=label_model_var, values=["gpt-5-nano","gpt-5-mini","gpt-5"]).grid(row=row, column=1, sticky="ew")
+    tb.Combobox(left, textvariable=label_model_var, values=["o4-mini","gpt-4o-mini","gpt-4o"]).grid(row=row, column=1, sticky="ew")
     row += 1
 
     tb.Label(left, text="QA‑Modell").grid(row=row, column=0, sticky="w")
-    tb.Combobox(left, textvariable=model_var, values=["gpt-5-mini","gpt-5"]).grid(row=row, column=1, sticky="ew", pady=(0,6))
+    tb.Combobox(left, textvariable=model_var, values=["gpt-4o-mini","gpt-4o"]).grid(row=row, column=1, sticky="ew", pady=(0,6))
     row += 1
 
     tb.Label(left, text="Gründlichkeit").grid(row=row, column=0, sticky="w")

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,3 @@
-"""
-Zentrale Anwendungskonfiguration. Sämtliche Einstellungen werden beim Start
-über `app.config.load_config` eingelesen und anschließend an die jeweiligen
-Module weitergereicht. Jede Option ist daher mit einem Hinweis versehen, wo sie
-im Code verwendet wird und welche Alternativen möglich sind.
-"""
-
 [auth]
 # Optionale API-Key-Quelle. Klartextspeicherung ist riskant!
 # api_key = "sk-..."
@@ -14,10 +7,10 @@ im Code verwendet wird und welche Alternativen möglich sind.
 # IDs der zu verwendenden OpenAI‑Modelle. Sie werden in `app.openai_client`
 # gelesen und bestimmen, welche Endpunkte für Klassifikation und Fragenantworten
 # angesprochen werden.
-label_model = "gpt-5-nano"          # für Segment-Klassifikation in `pipeline.classify`
-qa_model    = "gpt-5-mini"          # Modell für QA-Generierung; "gpt-5" liefert höhere Qualität
-use_json_mode = true                # steuert JSON-Modus in `openai_client`; nötig für strukturierte Antworten
-max_parallel_requests = 3           # maximale gleichzeitige API-Aufrufe in `openai_client`
+label_model = "gpt-4o-mini"       # für Segment-Klassifikation in `pipeline.classify`
+qa_model    = "gpt-4o"            # Modell für QA-Generierung; "o4-mini" ist eine schnellere Alternative
+use_json_mode = true               # steuert JSON-Modus in `openai_client`; nötig für strukturierte Antworten
+max_parallel_requests = 3          # maximale gleichzeitige API-Aufrufe in `openai_client`
 
 [chunking]
 # Steuergrößen für die Textsegmentierung in `app.chunking.split_into_chunks`.
@@ -36,21 +29,23 @@ max_questions_per_chunk_default = 8  # Begrenzung, wird von der GUI als Startwer
 [costs]
 # Preisangaben (USD pro 1 Mio Tokens) für die Kostenschätzung in
 # `pipeline.estimate_cost`. Werte können bei neuen Modellen angepasst werden.
-# GPT-5
-gpt-5_input_usd_per_mtok = 1250.0
-gpt-5_cached_input_usd_per_mtok = 0.125
-gpt-5_output_usd_per_mtok = 10000.0
 
-# GPT-5 Mini
-gpt-5-mini_input_usd_per_mtok = 250.0
-gpt-5-mini_cached_input_usd_per_mtok = 0.025
-gpt-5-mini_output_usd_per_mtok = 2000.0
+# GPT-4o
+gpt-4o_input_usd_per_mtok = 5.0
+gpt-4o_cached_input_usd_per_mtok = 0.5
+gpt-4o_output_usd_per_mtok = 15.0
 
-# GPT-5 Nano
-gpt-5-nano_input_usd_per_mtok = 50.0
-gpt-5-nano_cached_input_usd_per_mtok = 0.005
-gpt-5-nano_output_usd_per_mtok = 400.0
+# GPT-4o Mini
+gpt-4o-mini_input_usd_per_mtok = 0.15
+gpt-4o-mini_cached_input_usd_per_mtok = 0.015
+gpt-4o-mini_output_usd_per_mtok = 0.6
+
+# o4 Mini (Alternative für Klassifikation)
+o4-mini_input_usd_per_mtok = 2.0
+o4-mini_cached_input_usd_per_mtok = 0.2
+o4-mini_output_usd_per_mtok = 8.0
 
 [ui]
 # Darstellungsthema für die Tkinter-Oberfläche in `app.gui`.
 theme = "auto"    # "auto" | "light" | "dark"
+

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -1,6 +1,7 @@
 openai>=1.12.0
 tiktoken>=0.7.0
 pypdf>=4.2.0
+pdfplumber>=0.11.0
 pandas>=2.0.0
 openpyxl>=3.1.0
 toml>=0.10.2


### PR DESCRIPTION
## Summary
- Replace placeholder models with current OpenAI model IDs in config and GUI.
- Document a quick setup checklist and model note in the README.
- Add pdfplumber to installer requirements for improved PDF extraction.

## Testing
- `pip install -r installer/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af5c00ba48330a1bebd845e8fd089