### PR TITLE
Improve GUI scaling and config handling

### DIFF
--- a/app/theme.py
+++ b/app/theme.py
@@ -1,14 +1,29 @@
 from __future__ import annotations
-import platform, json, os, atexit
-import ttkbootstrap as tb
+
+import atexit
+import json
+import os
+import platform
 import tkinter as tk
 import tkinter.font as tkfont
+
+import ttkbootstrap as tb
 from ttkbootstrap.tooltip import ToolTip
 
 BASE_THEME = "superhero"      # Ausgangsbasis
 DEFAULT_THEME = "superhero_lila"  # dunkel / blau mit lila Akzent
 ALT_THEME = "flatly"          # hell / modern
-THEME_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets", "superhero_lila.json"))
+THEME_FILE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "assets", "superhero_lila.json")
+)
+
+
+def _minsize_for_screen(root: tk.Tk) -> tuple[int, int]:
+    """Mindestgröße relativ zur Bildschirmauflösung."""
+    w, h = root.winfo_screenwidth(), root.winfo_screenheight()
+    min_w = max(800, int(w * 0.6))
+    min_h = max(520, int(h * 0.6))
+    return min_w, min_h
 
 def make_root(title: str = "GSA Flashcards", theme: str = DEFAULT_THEME) -> tb.Window:
     _enable_hidpi_awareness()
@@ -19,7 +34,8 @@ def make_root(title: str = "GSA Flashcards", theme: str = DEFAULT_THEME) -> tb.W
     except Exception:
         root.style.theme_use(BASE_THEME)
     _apply_readability_tweaks(root)
-    root.minsize(960, 640)                 # genug Platz für 13" Displays
+    mw, mh = _minsize_for_screen(root)
+    root.minsize(mw, mh)
     _restore_geometry(root)                # letzte Fenstergröße wiederherstellen
     _persist_geometry_on_exit(root)
     return root
@@ -42,22 +58,35 @@ def _enable_hidpi_awareness():
     except Exception:
         pass
 
-def _restore_geometry(root: tk.Tk):
-    cfg = os.path.join(os.path.expanduser("~"), ".lernkarte_gui.json")
+def _cfg_path() -> str:
+    home = os.path.expanduser("~")
+    if platform.system() == "Windows":
+        base = os.path.join(home, "AppData", "Roaming", "Lernkarten")
+    else:
+        base = os.path.join(home, ".config", "lernkarten")
+    os.makedirs(base, exist_ok=True)
+    return os.path.join(base, "gui.json")
+
+
+def _restore_geometry(root: tk.Tk) -> None:
+    cfg = _cfg_path()
     try:
         if os.path.exists(cfg):
-            geo = json.load(open(cfg, "r", encoding="utf-8")).get("geometry")
+            with open(cfg, encoding="utf-8") as f:
+                geo = json.load(f).get("geometry")
             if geo:
                 root.geometry(geo)
     except Exception:
         pass
 
-def _persist_geometry_on_exit(root: tk.Tk):
-    cfg = os.path.join(os.path.expanduser("~"), ".lernkarte_gui.json")
+
+def _persist_geometry_on_exit(root: tk.Tk) -> None:
+    cfg = _cfg_path()
     @atexit.register
-    def _save():
+    def _save() -> None:
         try:
-            json.dump({"geometry": root.wm_geometry()}, open(cfg, "w", encoding="utf-8"))
+            with open(cfg, "w", encoding="utf-8") as f:
+                json.dump({"geometry": root.wm_geometry()}, f)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- Adjust GUI minimum size relative to screen resolution for better small-display support
- Store window geometry in a platform-appropriate config directory with safer file handling

## Testing
- `ruff check app/theme.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b89c332608330b579a80390adad68