### PR TITLE
Use environment variables for server config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ OPENAI_API_KEY=
 # OPENAI_BASE_URL=
 # HTTP_PROXY=
 # HTTPS_PROXY=
+#
+# Port for the Node server
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.pyc
 output.xlsx
 node_modules/
+.env
 # Distribution artifacts
 Lernkarten.zip
 start.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.7.2",
+        "dotenv": "^17.2.1",
         "express": "^4.18.2",
         "openai": "^5.12.2"
       }
@@ -194,6 +195,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^1.7.2",
+    "dotenv": "^17.2.1",
     "express": "^4.18.2",
     "openai": "^5.12.2"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+// Import modules
+const express = require('express');
+require('dotenv').config();  // Load .env file variables into process.env
+const app = express();
+
+// Set up server
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- load environment variables in Express server via `dotenv`
- document and ignore `.env` file with sample `PORT` setting
- add `dotenv` dependency for Node configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b91eec8888330916c01bcd58b536e