### PR TITLE
feat: improve Express error handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,19 @@
 // Import modules
 const express = require('express');
 require('dotenv').config();  // Load .env file variables into process.env
+const { getCards } = require('./routes/cards');
+
 const app = express();
+app.use(express.json());
+
+// Routes
+app.get('/cards', getCards);
+
+// Central error handling middleware
+app.use((err, req, res, next) => {
+  console.error('Unhandled error:', err);
+  res.status(500).json({ error: 'Interner Serverfehler' });
+});
 
 // Set up server
 const PORT = process.env.PORT || 3000;

--- a/src/models/card.js
+++ b/src/models/card.js
@@ -1,0 +1,11 @@
+const cards = [
+  { id: 1, question: 'Was ist 2+2?', answer: '4' },
+  { id: 2, question: 'Hauptstadt von Frankreich?', answer: 'Paris' }
+];
+
+async function findAll() {
+  // Simulate asynchronous database access
+  return cards;
+}
+
+module.exports = { findAll };

--- a/src/routes/cards.js
+++ b/src/routes/cards.js
@@ -1,0 +1,13 @@
+const Card = require('../models/card');
+
+async function getCards(req, res) {
+  try {
+    const cards = await Card.findAll();
+    res.json(cards);
+  } catch (error) {
+    console.error('Error fetching cards:', error);
+    res.status(500).json({ error: 'Interner Serverfehler' });
+  }
+}
+
+module.exports = { getCards };


### PR DESCRIPTION
## Summary
- add cards route with try/catch to return graceful HTTP 500 on DB errors
- introduce central Express error-handling middleware for unhandled exceptions
- provide basic Card model for demo data

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b94b9a3488330ad4ae1787ac0b120