### PR TITLE
Improve missing OpenAI package error message

### DIFF
--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -75,7 +75,8 @@ class OpenAIClient:
                 from openai import OpenAI
             except ImportError as e:
                 raise RuntimeError(
-                    "Das 'openai'-Paket ist nicht installiert. Bitte 'python install.py' ausführen."
+                    "Das 'openai'-Paket ist nicht installiert. Bitte fuehre "
+                    "'python install.py' aus (oder starte ueber 'run.bat')."
                 ) from e
             self._client = OpenAI(api_key=self.settings.api_key)
         return self._client


### PR DESCRIPTION
## Summary
- clarify instructions when OpenAI package is missing, directing to `python install.py` or `run.bat`

## Testing
- `ruff check app/openai_client.py` *(fails: Import block is un-sorted or un-formatted; multiple UP035 and other existing warnings)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba2b58aac83308bf685a67ec95e8c