### PR TITLE
Make GUI adaptable to small screens

### DIFF
--- a/app/gui.py
+++ b/app/gui.py
@@ -82,8 +82,8 @@ def run_gui():
 
     left = tb.Labelframe(center, text="Quelle & Einstellungen", padding=10)
     right = tb.Notebook(center)
-    center.add(left, weight=1, minsize=320)
-    center.add(right, weight=3, minsize=480)
+    center.add(left, weight=1)
+    center.add(right, weight=3)
 
     for c in range(2):
         left.columnconfigure(c, weight=1)

--- a/app/theme.py
+++ b/app/theme.py
@@ -21,8 +21,8 @@ THEME_FILE = os.path.abspath(
 def _minsize_for_screen(root: tk.Tk) -> tuple[int, int]:
     """Mindestgröße relativ zur Bildschirmauflösung."""
     w, h = root.winfo_screenwidth(), root.winfo_screenheight()
-    min_w = max(800, int(w * 0.6))
-    min_h = max(520, int(h * 0.6))
+    min_w = int(w * 0.6)
+    min_h = int(h * 0.6)
     return min_w, min_h
 
 def make_root(title: str = "GSA Flashcards", theme: str = DEFAULT_THEME) -> tb.Window:


### PR DESCRIPTION
## Summary
- compute window minsize relative to screen resolution without fixed 800x520 floor
- remove fixed min width for PanedWindow sections so layout can shrink on small displays

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e2737260c8330ac41a60b316e1f84