### PR TITLE
Add confirmation step before flashcard generation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -360,6 +360,20 @@ class App:
                     f"{len(filtered)} verbleiben."
                 )
 
+                # Warten auf Bestaetigung vor der Kartenerstellung
+                ToastNotification(
+                    title=APP_TITLE,
+                    message=(
+                        "Labeln fertig. Bitte pruefen und 'Fortsetzen' klicken, um die Lernkarten zu erzeugen."
+                    ),
+                    bootstyle="info",
+                ).show_toast()
+                self.progress.set("Warten auf Bestaetigung …")
+                self._pause_event.clear()
+                while not self._pause_event.wait(timeout=0.5):
+                    if self._stop_flag:
+                        return
+
                 # Lernkarten
                 self.progress.set("Erzeuge Lernkarten …")
                 self.logln("Fragen/Antworten werden generiert …")


### PR DESCRIPTION
## Summary
- Pause the pipeline after segment classification and wait for user confirmation before generating flashcards
- Display a toast notification instructing users to review segments and press resume

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e281d2a048330807446a36bfd761f