### PR TITLE
fix: remove unsupported response_format

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -45,7 +45,6 @@ def call_json_chat(model: str, system_prompt: str, user_prompt: str, temperature
             {"role": "user", "content": user_prompt},
         ],
         temperature=temperature,
-        response_format={"type": "json_object"},
         max_tokens=max_output_tokens,
     )
     raw = response.choices[0].message.content

--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -185,7 +185,6 @@ class OpenAIClient:
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
-            response_format={"type": "json_object"},
         )
         content = resp.choices[0].message.content
         try:
@@ -221,7 +220,6 @@ class OpenAIClient:
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
-            response_format={"type": "json_object"},
         )
         content = resp.choices[0].message.content
         try:

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -242,7 +242,8 @@ class LernkartenPipeline:
                 i, s = futures[fut]
                 try:
                     items: List[QAItem] = fut.result()
-                except Exception:
+                except Exception as e:
+                    logger.warning("OpenAI-Fehler: %s", e)
                     items = None
                 if not items:
                     if progress_cb:


### PR DESCRIPTION
## Summary
- remove unsupported `response_format` argument from OpenAI ChatCompletion calls
- log OpenAI exceptions when fetching QA items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e2b73c1d8833094596d42a71c1f86